### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate Models - using litellm

### DIFF
--- a/chain.py
+++ b/chain.py
@@ -4,7 +4,7 @@ from langchain.prompts.prompt import PromptTemplate
 from langchain.chains import ConversationalRetrievalChain, LLMChain
 from langchain.chains.question_answering import load_qa_chain
 from langchain.llms import OpenAI, Replicate
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatOpenAI, ChatLiteLLM
 from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.vectorstores import SupabaseVectorStore
 from supabase.client import Client, create_client
@@ -117,7 +117,7 @@ def get_chain_gpt(vectorstore, callback_handler=None):
         max_tokens=500,
     )
 
-    llm = ChatOpenAI(
+    llm = ChatLiteLLM(
         model_name="gpt-3.5-turbo",
         temperature=0.5,
         openai_api_key=st.secrets["OPENAI_API_KEY"],


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the OpenAI I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```